### PR TITLE
Rename the run method to parse

### DIFF
--- a/exampleparser/parser.py
+++ b/exampleparser/parser.py
@@ -69,7 +69,7 @@ class ExampleParser(FairdiParser):
             supported_compressions=['gz', 'bz2', 'xz']
         )
 
-    def run(self, mainfile: str, archive: EntryArchive, logger):
+    def parse(self, mainfile: str, archive: EntryArchive, logger):
         # Log a hello world, just to get us started. TODO remove from an actual parser.
         logger.info('Hello World')
 


### PR DESCRIPTION
This can hopefully save some time for another person trying to write a parser based on this example one and wondering why it fails with:

```
      File "....../nomad/nomad/parsing/parser.py", line 200, in parse
        raise NotImplementedError()
```