### PR TITLE
Update for latest NOMAD changes

### DIFF
--- a/exampleparser/__main__.py
+++ b/exampleparser/__main__.py
@@ -28,5 +28,5 @@ from exampleparser import ExampleParser
 if __name__ == "__main__":
     configure_logging(console_log_level=logging.DEBUG)
     archive = EntryArchive()
-    ExampleParser().run(sys.argv[1], archive, logging)
+    ExampleParser().parse(sys.argv[1], archive, logging)
     json.dump(archive.m_to_dict(), sys.stdout, indent=2)

--- a/exampleparser/metainfo/__init__.py
+++ b/exampleparser/metainfo/__init__.py
@@ -1,0 +1,31 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD.
+# See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sys
+from nomad.metainfo import Environment
+from nomad.metainfo.legacy import LegacyMetainfoEnvironment
+import exampleparser.metainfo.example
+import nomad.datamodel.metainfo.common
+import nomad.datamodel.metainfo.public
+import nomad.datamodel.metainfo.general
+
+m_env = LegacyMetainfoEnvironment()
+m_env.m_add_sub_section(Environment.packages, sys.modules['exampleparser.metainfo.example'].m_package)  # type: ignore
+m_env.m_add_sub_section(Environment.packages, sys.modules['nomad.datamodel.metainfo.common'].m_package)  # type: ignore
+m_env.m_add_sub_section(Environment.packages, sys.modules['nomad.datamodel.metainfo.public'].m_package)  # type: ignore
+m_env.m_add_sub_section(Environment.packages, sys.modules['nomad.datamodel.metainfo.general'].m_package)  # type: ignore

--- a/exampleparser/metainfo/example.py
+++ b/exampleparser/metainfo/example.py
@@ -16,9 +16,14 @@
 # limitations under the License.
 #
 
-from nomad.metainfo import Section, Quantity
+from nomad.metainfo import Section, Quantity, Package
 
 from nomad.datamodel.metainfo.public import section_single_configuration_calculation as SCC
+
+
+m_package = Package(
+    name='example_nomadmetainfo_json',
+    description='None')
 
 
 # We extend the existing common definition of a section "single configuration calculation"
@@ -30,3 +35,6 @@ class ExampleSCC(SCC):
     # We define an additional example quantity. Use the prefix x_<parsername>_ to denote
     # non common quantities.
     x_example_magic_value = Quantity(type=int, description='The magic value from a magic source.')
+
+
+m_package.__init_metainfo__()

--- a/exampleparser/parser.py
+++ b/exampleparser/parser.py
@@ -69,7 +69,7 @@ class ExampleParser(FairdiParser):
             supported_compressions=['gz', 'bz2', 'xz']
         )
 
-    def run(self, mainfile: str, archive: EntryArchive, logger):
+    def parse(self, mainfile: str, archive: EntryArchive, logger):
         # Log a hello world, just to get us started. TODO remove from an actual parser.
         logger.info('Hello World')
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -31,7 +31,7 @@ def parser():
 
 def test_example(parser):
     archive = EntryArchive()
-    parser.run('tests/data/example.out', archive, logging)
+    parser.parse('tests/data/example.out', archive, logging)
 
     run = archive.section_run[0]
     assert len(run.section_system) == 2


### PR DESCRIPTION
This should make it easier for someone starting from the example parser to be able to integrate the new parse into NOMAD, i.e., so that the nomad can detect the parser and read properly the parser-specific metainfo. Should address #7 .